### PR TITLE
Use $WERCKER_OUTPUT_DIR to store foam-extend

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -144,8 +144,7 @@ build:
         name: create archive
         code: |
             echo "export FOAM_INST_DIR=/home" >> foam-extend-3.2/etc/prefs.sh
-            tar -czf foam-extend-3.2.tar.gz foam-extend-3.2
-            rm -rf foam-extend-3.2
+            tar -czf $WERCKER_OUTPUT_DIR/foam-extend-3.2.tar.gz foam-extend-3.2
 
 dealii:
   steps:
@@ -342,8 +341,7 @@ debug:
         name: create archive
         code: |
             echo "export FOAM_INST_DIR=/home" >> foam-extend-3.2/etc/prefs.sh
-            tar -czf foam-extend-3.2.tar.gz foam-extend-3.2
-            rm -rf foam-extend-3.2
+            tar -czf $WERCKER_OUTPUT_DIR/foam-extend-3.2.tar.gz foam-extend-3.2
 
 dealii-debug:
   steps:
@@ -547,8 +545,7 @@ build-ubuntu:
         name: create archive
         code: |
             echo "export FOAM_INST_DIR=/home" >> foam-extend-3.2/etc/prefs.sh
-            tar -czf foam-extend-3.2.tar.gz foam-extend-3.2
-            rm -rf foam-extend-3.2
+            tar -czf $WERCKER_OUTPUT_DIR/foam-extend-3.2.tar.gz foam-extend-3.2
 
 dealii-ubuntu:
   box: ubuntu


### PR DESCRIPTION
In this manner, only the package is stored which is the only file needed for the dealii pipelines.
